### PR TITLE
Style project card with terminal theme

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -30,11 +30,15 @@ hr {
     margin : 10px auto;
 }
 
+#projects {
+    padding: 20px 0 30px;
+    text-align: center;
+}
+
 .project-card {
-    width: 20vw;
-    max-width: 40vw;
-    margin: 0 auto;
-    padding: 10px;
+    width: min(420px, 80vw);
+    margin: 20px auto 0;
+    padding: 16px;
 
     border-radius: 10px;
     box-shadow: 0 4px 8px grey;
@@ -65,3 +69,80 @@ hr {
     height: 50px;
 }
 
+.project-card--terminal {
+    background: #0b0f0c;
+    border: 1px solid #1f5b3a;
+    box-shadow: 0 10px 24px rgba(19, 161, 92, 0.25);
+    color: #d2f6df;
+    text-align: left;
+}
+
+.terminal-bar {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 10px;
+    background: #0f1a14;
+    border-radius: 8px 8px 0 0;
+    border-bottom: 1px solid #1f5b3a;
+}
+
+.terminal-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    display: inline-block;
+}
+
+.terminal-dot--red {
+    background: #ff5f57;
+}
+
+.terminal-dot--yellow {
+    background: #febc2e;
+}
+
+.terminal-dot--green {
+    background: #28c840;
+}
+
+.terminal-title {
+    margin-left: auto;
+    font-size: 0.75rem;
+    color: #7de2a3;
+    letter-spacing: 0.05em;
+}
+
+.terminal-body {
+    padding: 16px 12px 12px;
+}
+
+.project-card--terminal h3 {
+    margin: 10px 0 6px;
+    color: #d9ffe7;
+}
+
+.project-card--terminal p {
+    color: #a8e7c4;
+    line-height: 1.5;
+}
+
+.project-card--terminal .project-logo {
+    border-radius: 8px;
+    background: rgba(15, 26, 20, 0.8);
+    padding: 6px;
+}
+
+.project-card--terminal .project-card-links button {
+    background: #0f1a14;
+    border: 1px solid #2d8c58;
+    color: #b9f7d2;
+}
+
+.project-card--terminal .project-card-links button:hover {
+    background: #173022;
+}
+
+.project-card--terminal .project-card-links button:active {
+    background: #1b3b2a;
+}

--- a/index.html
+++ b/index.html
@@ -35,16 +35,23 @@
             <hr>
             <section id="projects">
                 <h2>My Work</h2>
-                <article class="project-card">
-                    <img class="project-logo" src="assets/symbols/apple.terminal.fill.svg" alt="Apple terminal logo">
-                    <h3>Trak</h3>
-                    <p>Trak is a swift console application desined to help terminal geeks trak their time spent of various tasks.</p>
-                    <div class="project-card-links">
-                        <button>Architecture</button>
-                        <button>GitHub Repo</button>
+                <article class="project-card project-card--terminal">
+                    <div class="terminal-bar">
+                        <span class="terminal-dot terminal-dot--red" aria-hidden="true"></span>
+                        <span class="terminal-dot terminal-dot--yellow" aria-hidden="true"></span>
+                        <span class="terminal-dot terminal-dot--green" aria-hidden="true"></span>
+                        <span class="terminal-title">trak-cli</span>
                     </div>
-                    
-                </article>            
+                    <div class="terminal-body">
+                        <img class="project-logo" src="assets/symbols/apple.terminal.fill.svg" alt="Apple terminal logo">
+                        <h3>Trak</h3>
+                        <p>Trak is a swift console application desined to help terminal geeks trak their time spent of various tasks.</p>
+                        <div class="project-card-links">
+                            <button>Architecture</button>
+                            <button>GitHub Repo</button>
+                        </div>
+                    </div>
+                </article>
             </section>
 
             


### PR DESCRIPTION
### Motivation

- Give the first project a CLI/terminal look because it represents a command-line application.
- Improve the project section layout and sizing for a cleaner, more consistent presentation.
- Provide a distinct visual palette and controls to communicate the project’s terminal nature.

### Description

- Updated `index.html` to change the first project card to `class="project-card project-card--terminal"` and added `terminal-bar` and `terminal-body` markup including colored control dots and a `terminal-title` label.
- Enhanced `css/main.css` with layout refinements for the `#projects` area and adjusted `.project-card` sizing and spacing to use `width: min(420px, 80vw)`.
- Added terminal-themed styles for `.project-card--terminal`, `.terminal-bar`, `.terminal-dot`, `.terminal-title`, and `.terminal-body` and tuned the `.project-logo` and `.project-card-links button` appearances to match the theme.
- Kept existing hover/transform behavior while updating colors, borders, and shadows to create a terminal-like aesthetic.

### Testing

- Served the site locally with `python -m http.server 8000` and the server started successfully.
- Ran a Playwright script to load the page and capture a screenshot (`artifacts/project-terminal.png`), which completed successfully.
- No unit or integration test suites were run for this static UI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c83194b0483308a29cc909a7625ea)